### PR TITLE
whitelist localhost ports

### DIFF
--- a/friend_me_backend/friend_me_backend/settings.py
+++ b/friend_me_backend/friend_me_backend/settings.py
@@ -63,6 +63,11 @@ CORS_ORIGIN_ALLOW_ALL = False
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:8000',
 )
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    # match localhost with any port
+    r"^http:\/\/localhost:*([0-9]+)?$",
+    r"^https:\/\/localhost:*([0-9]+)?$",
+]
 
 ROOT_URLCONF = 'friend_me_backend.urls'
 


### PR DESCRIPTION
white list local host ports so running flutter chrome locally doesn't require disabling web security