### PR TITLE
Add creater_name to serializer fields

### DIFF
--- a/friend_me_backend/events/serializers.py
+++ b/friend_me_backend/events/serializers.py
@@ -10,6 +10,7 @@ class EventSerializer(serializers.ModelSerializer):
   class Meta:
     model = Event
     fields = [
+      'creator_name',
       'title',
       'description',
       'start_time',


### PR DESCRIPTION
A quick fix for the "missing creator_name in fields" issue