### PR TITLE
Restructure urls and view for event

### DIFF
--- a/friend_me_backend/events/urls.py
+++ b/friend_me_backend/events/urls.py
@@ -1,11 +1,9 @@
-from django.urls import path, include
-from rest_framework import routers
-from rest_framework.routers import DefaultRouter
+from django.urls import path
 from events import views
 
-router = routers.DefaultRouter(trailing_slash=False)
-router.register(r'eventsdetails', views.Event)
-
 urlpatterns = [
-    path('', include(router.urls)),
+    # custom URL patterns for direct view functions
+    path('eventsdetails/', views.eventsdetails, name='eventsdetails'),
+    path('eventsdetails/<str:uid>/', views.events_by_uid, name='events_by_uid'),
+    path('eventsdetails/<int:pk>/', views.event_detail, name='event_detail'),
 ]

--- a/friend_me_backend/events/views.py
+++ b/friend_me_backend/events/views.py
@@ -1,48 +1,69 @@
-from django.shortcuts import render, redirect
 from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
 from events.models import Event
 from events.serializers import EventSerializer
-from rest_framework import viewsets
 from rest_framework import status
-from rest_framework.decorators import api_view
-from rest_framework.response import Response
 
-class Event(viewsets.ModelViewSet):
-    queryset = Event.objects.all()
-    serializer_class = EventSerializer
-
-@api_view(['GET', 'POST'])
-def events(request, format=None):
+# events in general with no filter
+# posting occurs as usual
+@csrf_exempt
+def eventsdetails(request, format=None):
     if request.method == 'GET':
         events = Event.objects.all()
         serializer = EventSerializer(events, many=True)
-        return Response(serializer.data)
+        return JsonResponse(serializer.data, safe=False)
     
     elif request.method == 'POST':
         serializer = EventSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return JsonResponse(serializer.data, status=status.HTTP_201_CREATED)
+        return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-@api_view(['GET', 'PUT', 'DELETE'])
+# processes requests based on uid string
+@csrf_exempt
+def events_by_uid(request, uid, format=None):
+    try:
+        event = Event.objects.get(uid=uid)
+    except Event.DoesNotExist:
+        return JsonResponse({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
+
+    if request.method == 'GET':
+        serializer = EventSerializer(event)
+        return JsonResponse(serializer.data)
+    
+    elif request.method == 'PUT':
+        data = request.data
+        serializer = EventSerializer(event, data=data)
+        if serializer.is_valid():
+            serializer.save()
+            return JsonResponse(serializer.data)
+        return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    elif request.method == 'DELETE':
+        event.delete()
+        return JsonResponse({'message': 'Event deleted successfully'}, status=status.HTTP_204_NO_CONTENT)
+    
+# processes requests based on pk (id for event)
+@csrf_exempt
 def event_detail(request, pk, format=None):
     try:
         event = Event.objects.get(pk=pk)
     except Event.DoesNotExist:
-        return Response(status=status.HTTP_404_NOT_FOUND)
+        return JsonResponse({'error': 'Event not found'}, status=status.HTTP_404_NOT_FOUND)
 
     if request.method == 'GET':
         serializer = EventSerializer(event)
-        return Response(serializer.data)
+        return JsonResponse(serializer.data)
 
     elif request.method == 'PUT':
-        serializer = EventSerializer(event, data=request.data)
+        data = request.data
+        serializer = EventSerializer(event, data=data)
         if serializer.is_valid():
             serializer.save()
-            return Response(serializer.data)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return JsonResponse(serializer.data)
+        return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     elif request.method == 'DELETE':
         event.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        return JsonResponse({'message': 'Event deleted successfully'}, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
This removes the router for eventsdetails, and replaces it with three endpoints. "eventsdetails/ " for general events with no filter, "eventsdetails/<str:uid>/ ", and "eventsdetails/<int:pk>/ "